### PR TITLE
Add ACM Digital Library to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,6 +428,7 @@ Available online at https://shubhanshu.com/awesome-scholarly-data-analysis/
 * [Data Set Knowledge Graph (DSKG) -  a RDF data set about data sets](http://dskg.org/)
 * [Citation Gecko - Find related papers](https://www.citationgecko.com)
 * [pySciSci - Python tool for working with MAG, PubMed, etc.](https://github.com/SciSciCollective/pyscisci)
+* [ACM Digital Library](https://dl.acm.org/)
 
 ## Tools for collecting open access papers
 


### PR DESCRIPTION
I added a link to ACM Digital Library. 
* [ACM Digital Library](https://dl.acm.org/)

It allows users to search for papers in the Association for Computing Machinery library.